### PR TITLE
feat: implement ACME Renewal Info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24
 
 require (
 	github.com/alibabacloud-go/alidns-20150109/v4 v4.5.7
+	github.com/alibabacloud-go/cas-20200407/v4 v4.0.0
 	github.com/alibabacloud-go/cdn-20180510/v5 v5.2.0
 	github.com/alibabacloud-go/darabonba-openapi/v2 v2.0.10
 	github.com/alibabacloud-go/tea-utils/v2 v2.0.7

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.5 h1:zE8vH9C7JiZLNJJQ5O
 github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.5/go.mod h1:tWnyE9AjF8J8qqLk645oUmVUnFybApTQWklQmi5tY6g=
 github.com/alibabacloud-go/alidns-20150109/v4 v4.5.7 h1:sY28duEZChZl7yWk+TWEJP9nKuqOwVyqYcyL8eX/N7E=
 github.com/alibabacloud-go/alidns-20150109/v4 v4.5.7/go.mod h1:W72lSO7HZPMeB7xdrOpQpQ42SvkwD5OxfLVfvdf0Nsk=
+github.com/alibabacloud-go/cas-20200407/v4 v4.0.0 h1:nCJ8Ih9IGTbcBrFUcUXQJ6IV/Mwm7jEYioVKOlTOgRI=
+github.com/alibabacloud-go/cas-20200407/v4 v4.0.0/go.mod h1:OuMv6sG1bj4nhzySA/mMdBcSAOJxpi9okEHqM5l73qo=
 github.com/alibabacloud-go/cdn-20180510/v5 v5.2.0 h1:ysyWiTgy3SyNKwUv8MjRIaRSoF/TGcEcRMtKD6is5L8=
 github.com/alibabacloud-go/cdn-20180510/v5 v5.2.0/go.mod h1:GnPiPL3HlzCi8SGiLiVgKrAFkP1vTtcF4yGtjsl4wfo=
 github.com/alibabacloud-go/darabonba-array v0.1.0 h1:vR8s7b1fWAQIjEjWnuF0JiKsCvclSRTfDzZHTYqfufY=

--- a/pkg/cas/cas.go
+++ b/pkg/cas/cas.go
@@ -1,0 +1,65 @@
+package cas
+
+import (
+	"auto-cert/pkg/ref"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+
+	aliCas "github.com/alibabacloud-go/cas-20200407/v4/client"
+	openapi "github.com/alibabacloud-go/darabonba-openapi/v2/client"
+)
+
+type Client struct {
+	c *aliCas.Client
+}
+
+func CreateClient(cfg *openapi.Config) (*Client, error) {
+	c, err := aliCas.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{c}, nil
+}
+
+type CertificateDetail struct {
+	Id          int64
+	Issuer      string
+	Cert        *x509.Certificate
+	SerialNo    string
+	Fingerprint string
+	Algorithm   string
+	NotBefore   int64
+}
+
+func (c *Client) GetCertificateDetail(certId int64) (*CertificateDetail, error) {
+	req := &aliCas.GetUserCertificateDetailRequest{
+		CertId:     ref.GetPointer(certId),
+		CertFilter: ref.GetPointer(true),
+	}
+
+	resp, err := c.c.GetUserCertificateDetail(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body := resp.Body
+	block, _ := pem.Decode([]byte(ref.DerefOrDefault(body.Cert)))
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, errors.New("Failed to decode PEM block containing certificate")
+	}
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	cd := &CertificateDetail{
+		Id:          ref.DerefOrDefault(body.Id),
+		Issuer:      *body.Issuer,
+		Cert:        leaf,
+		SerialNo:    ref.DerefOrDefault(body.SerialNo),
+		Fingerprint: ref.DerefOrDefault(body.Fingerprint),
+		Algorithm:   ref.DerefOrDefault(body.Algorithm),
+		NotBefore:   ref.DerefOrDefault(body.NotBefore),
+	}
+	return cd, nil
+}

--- a/pkg/cdn/cdn.go
+++ b/pkg/cdn/cdn.go
@@ -68,6 +68,8 @@ func (c *Client) QueryDomainCertificate(domain string) (*CertInfo, error) {
 		DomainName: ref.DerefOrDefault(certInfo.DomainName),
 		Name:       ref.DerefOrDefault(certInfo.CertName),
 		Enabled:    ref.DerefOr(certInfo.ServerCertificateStatus, statusOff) == statusOn,
+		Id:         ref.DerefOrDefault(certInfo.CertId),
+		Type:       ref.DerefOrDefault(certInfo.CertType),
 		Region:     ref.DerefOrDefault(certInfo.CertRegion),
 	}
 	// format: 2018-06-03T22:03:39Z


### PR DESCRIPTION
The `x/crypto/acme` package does not support ACME Renewal Information standard: https://redirect.github.com/golang/go/issues/60958. Wait for the implementation of it.
